### PR TITLE
Make Source pub

### DIFF
--- a/src/tinify.rs
+++ b/src/tinify.rs
@@ -1,4 +1,4 @@
-use crate::client::Client;
+pub use crate::client::Client;
 pub use crate::source::Source;
 use lazy_static::lazy_static;
 use std::collections::HashMap;

--- a/src/tinify.rs
+++ b/src/tinify.rs
@@ -1,5 +1,5 @@
 use crate::client::Client;
-use crate::source::Source;
+pub use crate::source::Source;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::sync::Mutex;


### PR DESCRIPTION
Currently `Source` is not usable from outside the library but gets returned by both `from_file`as well as `from_buffer`.
For my use case its preferable to use `Source` instead of already converting it to `Vec<u8>` or similar. 
Therefore public access to `Source` is necessary.

Maybe it would make sense to make `Client` public as well since its also available over the public interface via the `get_client` function. Tell me if I should include this as well